### PR TITLE
Delete modu düzeltmeleri ve LearnVC navigasyon işlevselliği

### DIFF
--- a/mathSolver/Views/Home/History/Cells/HistoryCell.swift
+++ b/mathSolver/Views/Home/History/Cells/HistoryCell.swift
@@ -11,6 +11,8 @@ import SnapKit
 final class HistoryCell: UICollectionViewCell {
     static let identifier = Constants.Cells.HistoryCell.identifier
     
+    private var deleteAction: (() -> Void)?
+    
     private lazy var containerView: UIImageView = {
         let imageView = UIImageView()
         imageView.image = UIImage(named: "background")
@@ -37,8 +39,6 @@ final class HistoryCell: UICollectionViewCell {
         button.addTarget(self, action: #selector(handleDelete), for: .touchUpInside)
         return button
     }()
-    
-    private var deleteAction: (() -> Void)?
     
     override init(frame: CGRect) {
         super.init(frame: frame)


### PR DESCRIPTION
- Delete modu aktifken collectionView hücrelerine tıklanıldığında LearnVC'ye geçiş sağlanması eklendi.
- HistoryCell içindeki deleteButton için aksiyon yönetimi güncellendi.
- handleTapOutside metodu güncellenerek delete modu kontrolleri iyileştirildi.
- collectionView(_:didSelectItemAt:) metodu güncellenerek delete modu durumunda doğru işlevselliği sağlama düzenlemesi yapıldı.
